### PR TITLE
Keep awareness active when changing chats

### DIFF
--- a/src/components/middle/immedia/Immedia.tsx
+++ b/src/components/middle/immedia/Immedia.tsx
@@ -127,11 +127,6 @@ const Immedia: FC<OwnProps & StateProps> = ({ chatId, currentUser }) => {
     }
   };
 
-  useEffect(() => {
-    // If the user changed chats, we need to clean up the old chat.
-    cleanUp();
-  }, [chatId]);
-
   const createConnection = () => {
     wsRef.current = new SockJS(WEBSOCKET_URL);
     wsRef.current.onopen = () => console.log(INIT, 'ws opened');


### PR DESCRIPTION
Addresses https://github.com/ekumenlabs/telegram-tt/issues/3

When changing chats, the awareness is still open.

Can you ptal @mattborghi ?