### PR TITLE
Enable awareness for specific chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This component can be disabled as well by clicking the `Disable Awareness` butto
 
 ![immedia-disabled](./assets/immedia/disable.png)
 
+> **Dev Note:** An env variable needs to be added to your `.env` file to enable Immedia with the `IMMEDIA_ROOM_ID` variable corresponding to the chat id of the group/chat you want to enable. For example: `IMMEDIA_ROOM_ID=-1188795392`.
+
 ### Invoking API from console
 
 Start your dev server and locate GramJS worker in console context.

--- a/src/components/middle/immedia/Immedia.tsx
+++ b/src/components/middle/immedia/Immedia.tsx
@@ -432,13 +432,15 @@ const Immedia: FC<OwnProps & StateProps> = ({ chatId, currentUser }) => {
         )}
       </div>
       {/* Action Buttons */}
-      <Button
-        className="enable-disable-awareness"
-        color="primary"
-        onClick={awareness ? disableAwareness : enableAwareness}
-      >
-        {awareness ? 'Disable Awareness' : 'Enable Awareness'}
-      </Button>
+      { process.env.IMMEDIA_ROOM_ID !== undefined && process.env.IMMEDIA_ROOM_ID === chatId && (
+        <Button
+          className="enable-disable-awareness"
+          color="primary"
+          onClick={awareness ? disableAwareness : enableAwareness}
+        >
+          {awareness ? 'Disable Awareness' : 'Enable Awareness'}
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/components/middle/immedia/helpers.ts
+++ b/src/components/middle/immedia/helpers.ts
@@ -1,3 +1,12 @@
 const formatRoom = (room: string) => room.replace('-', 's');
 
+const definedRoom = () => {
+  if (process.env.IMMEDIA_ROOM_ID === '') {
+    // eslint-disable-next-line no-console
+    console.error('IMMEDIA_ROOM_ID is not defined in the .env file.');
+  }
+};
+
+definedRoom();
+
 export { formatRoom };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -118,6 +118,7 @@ module.exports = (env = {}, argv = {}) => {
         TELEGRAM_T_API_ID: '',
         TELEGRAM_T_API_HASH: '',
         TEST_SESSION: '',
+        IMMEDIA_ROOM_ID: '',
       }),
       new ProvidePlugin({
         Buffer: ['buffer', 'Buffer'],


### PR DESCRIPTION
Awareness is now only enabled for the chat id specified on the `IMMEDIA_ROOM_ID` env var.

This feature finally closes #3.