### PR TITLE
Use HTTPS instead of SSH for installing dependencies in deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,5 +20,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install # npm ci fails
-      - run: npm run deploy:production
+          persist-credentials: false
+
+      - name: Reconfigure git to use HTTP authentication
+        run: >
+          git config --global url."https://github.com/".insteadOf
+          ssh://git@github.com/
+      - name: Install dependencies
+        run: npm ci
+      - name: Deployment script
+        run: npm run deploy:production


### PR DESCRIPTION
Some dependencies point to github

https://github.com/ekumenlabs/telegram-tt/blob/767cd3ce480518a6e7888685467e3b7003c97e16/package.json#L78

and it tries to install them using `git+ssh` but we need to use `https` instead.

Fix based on this suggestion https://github.com/actions/setup-node/issues/214#issuecomment-810829250