### PR TITLE
use HTTPS instead of SSH for test action when installing dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,13 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+        persist-credentials: false
+
+    - name: Reconfigure git to use HTTP authentication
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
+        
     - run: npm ci
     - run: npm run gramjs:tl
     - run: npm test


### PR DESCRIPTION
Solved the same issue as #10 but in the tests action.