### PR TITLE
Sign-off publishing commit for gh-pages script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Deployment script
-        run: npm run deploy:production
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npm run deploy:production -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Following `gh-pages'` guide https://github.com/tschaub/gh-pages#deploying-with-github-actions-and-a-named-script, additional configurations need to be set in order to automate the deployment using github actions.