### PR TITLE
Add action that fetches upstream repository

### DIFF
--- a/.github/workflows/fetch_upstream.yml
+++ b/.github/workflows/fetch_upstream.yml
@@ -1,0 +1,51 @@
+name: Fetch upstream from Ajaxy/telegram-tt
+on: 
+  schedule:
+    - cron: '0 0 1 * *'
+    # scheduled for 00:00 every first day of the month
+
+  workflow_dispatch:
+    inputs:
+      upstream:
+        description: 'Upstream repository Ajaxy/telegram-tt.'
+        required: true
+        default: 'Ajaxy/telegram-tt'       # set the upstream repo
+      upstream-branch:
+        description: 'Upstream branch to merge from.'
+        required: true
+        default: 'master'           # set the upstream branch to merge from
+      branch:
+        description: 'Branch to merge to'
+        required: true
+        default: 'upstream_sync'         # set the branch to merge to
+
+jobs:
+  merge-upstream:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 0 
+      - name: Merge Upstream (Cubik65536's Fork)
+        uses: Cubik65536/merge-upstream@v1.1.3
+        with:
+          upstream: ${{ github.event.inputs.upstream }}
+          upstream-branch: ${{ github.event.inputs.upstream-branch }}
+          branch: ${{ github.event.inputs.branch }}
+          token: ${{ secrets.TOKEN }}
+  # Create a pull request from the fetched commits
+  auto-pull-request:
+    needs: merge-upstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: pull-request-action
+        uses: vsoch/pull-request-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_TITLE: "Fetching Upstream changes from Ajaxy/telegram-tt"
+          PULL_REQUEST_BODY: "This is an automated PR that fetches new commits from `Ajaxy/telegram-tt` that are updated in the `upstream_sync` branch."
+          PULL_REQUEST_UPDATE: true
+          PULL_REQUEST_FROM_BRANCH: "upstream_sync"


### PR DESCRIPTION
### Steps before merging the PR

- [x] Create a new branch called `upstream-sync` bringing commits until c3d55e58b5952c78687b8d1ac36348fc2d73f48f. This branch will track latest commits from `Ajaxy/telegram-tt`.

  ``` 
  git checkout master
  git branch upstream-sync c3d55e58b5952c78687b8d1ac36348fc2d73f48f
  git push origin upstream-sync
  ```

To test this we can wait until the action is triggered (at 00:00 on day-of-month 1) or make a manual trigger. The following steps will be executed:
1. Fetch latest commits from `Ajaxy/telegram-tt` into `upstream-sync` branch. If necessary there will be a commit created.
2. Create a PR from `upstream-sync` to `master`. If the PR was already created it will only update it with new commits. 

> **DON'T DELETE upstream-sync BRANCH AFTER MERGING PRs AS THE FETCHING FAILS IF THE BRANCH DOES NOT EXISTS**  
In order to solve this, we can replace this line https://github.com/Cubik65536/merge-upstream/blob/9c056aca0810f6ab41d7a69df022c36f0cc63177/action.yml#L42 with `git switch -C "${{ inputs.branch }}"`