### PR TITLE
Improve display of long usernames

### DIFF
--- a/src/components/middle/immedia/Immedia.scss
+++ b/src/components/middle/immedia/Immedia.scss
@@ -33,6 +33,8 @@
   flex-direction: column;
   align-items: stretch;
   margin-bottom: 3px;
+  max-width: 70px;
+  overflow: hidden;
 }
 
 .participant-me {

--- a/src/components/middle/immedia/Immedia.tsx
+++ b/src/components/middle/immedia/Immedia.tsx
@@ -404,6 +404,7 @@ const Immedia: FC<OwnProps & StateProps> = ({ chatId, currentUser }) => {
               </video>
               <canvas
                 ref={canvasMeRef}
+                className="photo-canvas"
                 width="70"
                 height="50"
               />


### PR DESCRIPTION
This PR improves the display of long usernames to a fix width of `70px`.