### PR TITLE
Fix automatically triggered github action

### DIFF
--- a/.github/workflows/fetch_upstream.yml
+++ b/.github/workflows/fetch_upstream.yml
@@ -4,21 +4,6 @@ on:
     - cron: '0 0 1 * *'
     # scheduled for 00:00 every first day of the month
 
-  workflow_dispatch:
-    inputs:
-      upstream:
-        description: 'Upstream repository Ajaxy/telegram-tt.'
-        required: true
-        default: 'Ajaxy/telegram-tt'       # set the upstream repo
-      upstream-branch:
-        description: 'Upstream branch to merge from.'
-        required: true
-        default: 'master'           # set the upstream branch to merge from
-      branch:
-        description: 'Branch to merge to'
-        required: true
-        default: 'upstream_sync'         # set the branch to merge to
-
 jobs:
   merge-upstream:
     runs-on: ubuntu-latest
@@ -31,9 +16,9 @@ jobs:
       - name: Merge Upstream (Cubik65536's Fork)
         uses: Cubik65536/merge-upstream@v1.1.3
         with:
-          upstream: ${{ github.event.inputs.upstream }}
-          upstream-branch: ${{ github.event.inputs.upstream-branch }}
-          branch: ${{ github.event.inputs.branch }}
+          upstream: 'Ajaxy/telegram-tt'
+          upstream-branch: 'master'
+          branch: 'upstream_sync'
           token: ${{ secrets.TOKEN }}
   # Create a pull request from the fetched commits
   auto-pull-request:


### PR DESCRIPTION
Currently, the github action that triggers automatically every first day of the month is [failling](https://github.com/ekumenlabs/telegram-tt/actions/runs/1775736476) because it can't read input values from the repo such as: upstream repo, repo branches, etc.
This information is sent under the `workflow_dispatch` block which is incorrect. This has to be used only for manually triggering an action as seen [here](https://github.com/Cubik65536/merge-upstream#how-to-run-this-action-manually). In order for the github action to see this information, data should be passed under the `with` block directly as shown [here](https://github.com/Cubik65536/merge-upstream#set-up-for-scheduled-trigger).