### PR TITLE
Create CNAME file when building production environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "cross-env APP_ENV=development webpack serve --env mode=dev --env isDevServer --mode development --config ./webpack.config.js",
     "build": "webpack --mode production",
     "build:staging": "rm -rf dist/ && APP_ENV=staging npm run build && ./deploy/copy_to_dist.sh",
-    "build:production": "npm i && rm -rf dist/ && APP_VERSION=$(npm run inc_version --silent) APP_ENV=production npm run build && ./deploy/copy_to_dist.sh",
+    "build:production": "npm i && rm -rf dist/ && APP_VERSION=$(npm run inc_version --silent) APP_ENV=production npm run build && npm run cname && ./deploy/copy_to_dist.sh",
     "deploy:production": "npm run build:production && gh-pages -d dist --message '[EKUDEPLOY] Deployed to Github Pages'",
     "inc_version": "echo $((`cat .patch-version` + 1)) > .patch-version && echo \"$(node -p -e \"require('./package.json').version.match(/^\\d+\\.\\d+/)[0]\").$(cat .patch-version)\"",
     "perf:serve": "cross-env APP_ENV=perf parcel src/index-perf.html",
@@ -18,6 +18,7 @@
     "gramjs:lint:fix": "eslint ./src/lib/gramjs --ignore-path=src/lib/gramjs/.eslintignore --fix",
     "test": "cross-env APP_ENV=test jest --verbose --forceExit",
     "test:verbose": "cross-env APP_ENV=test jest --verbose",
+    "cname": "echo \"webogram.ekumenlabs.com\" > dist/CNAME",
     "prepare": "husky install"
   },
   "engines": {


### PR DESCRIPTION
Auto deploying production environments overwrites CNAME variable to empty. So, although the deployment is working for the github page `ekumenlabs.github.io/telegram-tt`, `webogram.ekumenlabs.com` doens't work.

### Manual Solution

Overwrite on the Settings panel under Pages, the Custom Domain's variable CNAME to `webogram.ekumenlabs.com`.

### This PR

Makes the manual solution explained above automatically by creating a `CNAME` file with `webogram.ekumenlabs.com`.inside it.
