### PR TITLE
Change update rate of snapshots sent to the server

### DIFF
--- a/src/components/middle/immedia/Immedia.tsx
+++ b/src/components/middle/immedia/Immedia.tsx
@@ -361,7 +361,7 @@ const Immedia: FC<OwnProps & StateProps> = ({ chatId, currentUser }) => {
 
   useInterval(() => {
     sendUpdate();
-  }, awareness && connected && userId ? UPDATE_RATE : undefined);
+  }, awareness && connected && userId && lastSnapshot ? UPDATE_RATE : undefined);
 
   // TODO: Define the Heartbeat function to keep track user connection.
   // Keep Track of connection status

--- a/src/components/middle/immedia/constants.ts
+++ b/src/components/middle/immedia/constants.ts
@@ -10,7 +10,7 @@ const GC_RATE = 1500; // 1.5 seconds
 const REMOVE_THRESHOLD = 1000 * 20; // 20 seconds
 const SNAPSHOT_RATE = 500; // 0.5 seconds
 const PING_RATE = 1000 * 5; // 5 seconds
-const UPDATE_RATE = 1000 * 1; // 1 second
+const UPDATE_RATE = 500 * 1; // 0.5 seconds
 
 export { WEBSOCKET_URL };
 export { INIT };


### PR DESCRIPTION
Webcam snapshots are sent every 0.5 seconds making the participant movement smoother.